### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changelog
 ===========
 
-3.2 (unreleased)
+4.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 3.1 (2025-02-13)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*rnames):
 
 setup(
     name='zope.browser',
-    version='3.2.dev0',
+    version='4.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='Shared Zope Toolkit browser components',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 """Setup for zope.browser package"""
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -56,9 +55,6 @@ setup(
         'Framework :: Zope :: 3',
     ],
     url='https://zopebrowser.readthedocs.io',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',
@@ -71,7 +67,7 @@ setup(
             'repoze.sphinx.autointerface',
         ],
         'test': [
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ],
     },
     include_package_data=True,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: nocover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
